### PR TITLE
feat: add PHPUnit 10, 11, and 12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,18 @@ jobs:
       - name: Create build directory
         run: mkdir -p build/logs
 
+      - name: Determine PHPUnit config
+        id: phpunit-config
+        run: |
+          PHPUNIT_VERSION=$(vendor/bin/phpunit --version | grep -oP '\d+' | head -1)
+          if [ "$PHPUNIT_VERSION" -ge 10 ]; then
+            echo "config=phpunit.xml.dist" >> $GITHUB_OUTPUT
+          else
+            echo "config=phpunit9.xml.dist" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run tests
-        run: vendor/bin/phpunit --testdox --coverage-clover build/logs/clover.xml
+        run: vendor/bin/phpunit --configuration ${{ steps.phpunit-config.outputs.config }} --testdox --coverage-clover build/logs/clover.xml
 
       - name: Code Coverage Annotation
         uses: ggilder/codecoverage@47c83daaf1d5a3190cad56363baf459c59114170 # v1

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 composer.lock
 build
 .phpunit.result.cache
+.phpunit.cache
 .php_cs.cache
 .php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "php": "^7.3||^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5 || ^10 || ^11 || ^12",
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^2.1"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-    </report>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         failOnRisky="true"
+         failOnWarning="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerWarnings="true">
   <testsuites>
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests/src/Unit</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
   <logging>
     <junit outputFile="build/logs/results.xml"/>
   </logging>

--- a/phpunit9.xml.dist
+++ b/phpunit9.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/src/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/logs/results.xml"/>
+  </logging>
+</phpunit>


### PR DESCRIPTION
- Update composer.json to support PHPUnit ^9.5 || ^10 || ^11 || ^12
- Update minimum PHP version from 7.3 to 7.4 (matching CI matrix)
- Create PHPUnit 10+ compatible phpunit.xml.dist with new schema
- Add phpunit9.xml.dist for legacy PHPUnit 9 support on PHP 7.4/8.0
- Update CI workflow to detect PHPUnit version and use appropriate config
- Add .phpunit.cache to .gitignore for PHPUnit 10+ cache directory