### PR TITLE
ci: add code coverage percentage check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run tests
         run: vendor/bin/phpunit --configuration ${{ steps.phpunit-config.outputs.config }} --testdox --coverage-clover build/logs/clover.xml
 
+      - name: Check coverage threshold
+        run: php scripts/check-coverage-threshold.php build/logs/clover.xml
+
       - name: Code Coverage Annotation
         uses: ggilder/codecoverage@47c83daaf1d5a3190cad56363baf459c59114170 # v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         pass_filenames: false
       - id: phpunit
         name: PHPUnit
-        entry: vendor/bin/phpunit --testdox
+        entry: bash -c 'XDEBUG_MODE=coverage vendor/bin/phpunit --testdox'
         language: system
         types: [php]
         pass_filenames: false

--- a/scripts/check-coverage-threshold.php
+++ b/scripts/check-coverage-threshold.php
@@ -1,0 +1,47 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$cloverPath = $argv[1] ?? 'build/logs/clover.xml';
+$threshold = 97.0;
+
+if (!file_exists($cloverPath)) {
+    fwrite(STDERR, "Error: Clover XML file not found at: $cloverPath\n");
+    exit(1);
+}
+
+$xml = simplexml_load_file($cloverPath);
+if ($xml === false) {
+    fwrite(STDERR, "Error: Failed to parse clover XML file\n");
+    exit(1);
+}
+
+$metrics = $xml->project->metrics;
+if ($metrics === null) {
+    fwrite(STDERR, "Error: No project metrics found in clover XML\n");
+    exit(1);
+}
+
+$statements = (int) $metrics['statements'];
+$coveredStatements = (int) $metrics['coveredstatements'];
+
+if ($statements === 0) {
+    fwrite(STDERR, "Error: No statements found in coverage report\n");
+    exit(1);
+}
+
+$coverage = ($coveredStatements / $statements) * 100;
+
+printf("Coverage: %.3f%% (%d/%d statements)\n", $coverage, $coveredStatements, $statements);
+
+if ($coverage < $threshold) {
+    fwrite(STDERR, sprintf(
+        "::error::Coverage %.3f%% is below the required threshold of %.1f%%\n",
+        $coverage,
+        $threshold
+    ));
+    exit(1);
+}
+
+echo "Coverage meets the required threshold of {$threshold}%\n";

--- a/scripts/check-coverage-threshold.php
+++ b/scripts/check-coverage-threshold.php
@@ -4,7 +4,7 @@
 declare(strict_types=1);
 
 $cloverPath = $argv[1] ?? 'build/logs/clover.xml';
-$threshold = 97.0;
+$threshold = 100.0;
 
 if (!file_exists($cloverPath)) {
     fwrite(STDERR, "Error: Clover XML file not found at: $cloverPath\n");


### PR DESCRIPTION
Add a script to verify code coverage meets 97% threshold and integrate it into the test workflow. This ensures coverage doesn't regress below the required minimum.

Also fix pre-commit PHPUnit hook to set XDEBUG_MODE for coverage.