### PR TITLE
fix(deps): sync actionlint versions and update Renovate config

### DIFF
--- a/.claude/hooks/SessionStart.sh
+++ b/.claude/hooks/SessionStart.sh
@@ -91,7 +91,7 @@ fi
 echo "Checking for actionlint..."
 if ! command -v actionlint &> /dev/null && [ ! -f "./actionlint" ]; then
     echo "actionlint is not installed. Downloading actionlint..."
-    bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.10/scripts/download-actionlint.bash) 1.7.9
+    bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.10/scripts/download-actionlint.bash) 1.7.10
     echo "actionlint installed successfully!"
 else
     echo "actionlint is already available."

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Download actionlint
         id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.10/scripts/download-actionlint.bash) 1.7.9
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.10/scripts/download-actionlint.bash) 1.7.10
         shell: bash
       - name: Check workflow files
         run: ${{ steps.get_actionlint.outputs.executable }} -color

--- a/renovate.json
+++ b/renovate.json
@@ -25,10 +25,12 @@
         "/^\\.claude/hooks/SessionStart\\.sh$/"
       ],
       "matchStrings": [
-        "rhysd/actionlint/(?<currentValue>v[0-9.]+)/scripts/download-actionlint\\.bash"
+        "rhysd/actionlint/(?<currentValue>v[0-9.]+)/scripts/download-actionlint\\.bash\\)( (?<currentValue>[0-9.]+))?"
       ],
+      "autoReplaceStringTemplate": "rhysd/actionlint/{{{newVersion}}}/scripts/download-actionlint.bash) {{{newValue}}}",
       "depNameTemplate": "rhysd/actionlint",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
The actionlint download command had mismatched versions (v1.7.10 in URL, 1.7.9 as argument). Both were updated to 1.7.10, and the Renovate custom manager was modified to use autoReplaceStringTemplate to ensure version synchronization on future updates.