### PR TITLE
ci: add Renovate config validation

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -1,0 +1,33 @@
+name: Validate Renovate config
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'renovate.json'
+      - 'renovate.json5'
+      - '.renovaterc'
+      - '.renovaterc.json'
+      - '.renovaterc.json5'
+      - '.github/renovate.json'
+      - '.github/renovate.json5'
+  pull_request:
+    paths:
+      - 'renovate.json'
+      - 'renovate.json5'
+      - '.renovaterc'
+      - '.renovaterc.json'
+      - '.renovaterc.json5'
+      - '.github/renovate.json'
+      - '.github/renovate.json5'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@c22827f47f4f4a5364bdba19e1fe36907ef1318e # v1.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,10 @@ repos:
     rev: v1.7.9
     hooks:
       - id: actionlint
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 42.71.0
+    hooks:
+      - id: renovate-config-validator
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.0.0
     hooks:


### PR DESCRIPTION
Add renovate-config-validator pre-commit hook to validate Renovate configuration on commit. Also add a GitHub Actions workflow to validate Renovate config on pushes and PRs that modify renovate config files.