### PR TITLE
chore: configure Renovate to automerge all updates after 3 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,11 +35,8 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "matchCurrentVersion": "!/^0/",
+      "matchPackagePatterns": ["*"],
+      "minimumReleaseAge": "3 days",
       "automerge": true
     },
     {


### PR DESCRIPTION
Update the packageRules to automerge all package updates with a minimum release age of 3 days, replacing the previous rule that only automerged minor/patch updates for non-0.x versions.