### PR TITLE
chore: add prCreation and internalChecksFilter to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
   "extends": [
     "config:recommended",
     ":preserveSemverRanges",


### PR DESCRIPTION
Add prCreation="not-pending" and internalChecksFilter="strict" to ensure branches and PRs are only created after the minimumReleaseAge has passed.