### PR TITLE
fix(renovate): restore v prefix in actionlint autoreplace template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,7 @@
       "matchStrings": [
         "rhysd/actionlint/v(?<currentValue>[0-9.]+)/scripts/download-actionlint\\.bash\\) [0-9.]+"
       ],
-      "autoReplaceStringTemplate": "rhysd/actionlint/{{{newVersion}}}/scripts/download-actionlint.bash) {{{newValue}}}",
+      "autoReplaceStringTemplate": "rhysd/actionlint/v{{{newVersion}}}/scripts/download-actionlint.bash) {{{newValue}}}",
       "depNameTemplate": "rhysd/actionlint",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"


### PR DESCRIPTION
## Summary
- Renovate was failing to update `rhysd/actionlint` with `⚠️ WARN: Error updating branch: update failure` (1.7.10 → 1.7.12).
- Root cause: `autoReplaceStringTemplate` dropped the `v` prefix that the `matchStrings` regex (`rhysd/actionlint/v(?<currentValue>...)`) requires. Because `extractVersionTemplate` strips the `v`, `{{{newVersion}}}` expands to `1.7.12`, so the rewritten file no longer matched the regex and Renovate's post-write re-extraction aborted the branch.
- Fix: prepend `v` in the replacement template so the file remains parseable after autoreplace.

## Test plan
- [ ] Next Renovate run produces the `rhysd/actionlint` v1.7.12 PR without `update failure`
- [ ] Resulting diff to `.github/workflows/actionlint.yml` and `.claude/hooks/SessionStart.sh` keeps the `v` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)